### PR TITLE
Fix get default route if (close GH-1)

### DIFF
--- a/example/firewall.sh
+++ b/example/firewall.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-dev=$(ip -4 r|awk '/^default/ {print $5}')
+dev=$(ip -4 r|awk '/^default via/ {print $5}')
 iptables -A FORWARD -i bibi0 -j ACCEPT
 iptables -A FORWARD -o bibi0 -j ACCEPT
 iptables -t nat -A POSTROUTING -o $dev -j MASQUERADE


### PR DESCRIPTION
If a VPN is mounted another default route exist (with a different metric)

❯ sudo ./firewall.sh
Bad argument `link'
Try`iptables -h' or 'iptables --help' for more information.
❯ ip -4 r|awk '/^default/ {print $5}'
wlan0
link
❯ ip -4 r |head -2
default via 192.168.1.1 dev wlan0
default dev eth0  scope link  metric 1002
