### PR TITLE
support multiple roles in a config

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ container.
 
 It will deploy a set of LXC containers based on:
 
-- a eDeploy role
+- eDeploy roles
 - IP and host from a YAML conf
 
 ## use case

--- a/edeploy-lxc
+++ b/edeploy-lxc
@@ -70,17 +70,25 @@ def stop():
 def start():
     start_bridge()
 
-    if not os.path.exists('/var/lib/lxc/basesys/rootfs'):
-        os.makedirs('/var/lib/lxc/basesys/rootfs')
 
-    subprocess.call(['rsync', '-av', '--delete', '--numeric-ids', '%s/' % conf['edeploy']['dir'], '/var/lib/lxc/basesys/rootfs'])
-    subprocess.call(['tar', 'xf', '/usr/share/debootstrap/devices.tar.gz'], cwd='/var/lib/lxc/basesys/rootfs')
+    roles = []
+    
+    for host in conf['hosts']:
+        if host['role'] not in roles:
+            roles.append(host['role'])
 
-    if not os.path.exists('/var/lib/lxc/basesys/rootfs/dev/pts'):
-        os.makedirs('/var/lib/lxc/basesys/rootfs/dev/pts')
+    for role in roles:
+        rootfs = '/var/lib/lxc/%s/rootfs' % role
+        if not os.path.exists(rootfs):
+            os.makedirs(rootfs)
+        subprocess.call(['rsync', '-av', '--delete', '--numeric-ids', '%s/%s/' % (conf['edeploy']['dir'], role), rootfs])
+        subprocess.call(['tar', 'xf', '/usr/share/debootstrap/devices.tar.gz'], cwd=rootfs)
 
-    # work around for LXC bug, rmmod module on the host system
-    shutil.copyfile('/var/lib/lxc/basesys/rootfs/bin/echo', '/var/lib/lxc/basesys/rootfs/bin/kmod')
+        if not os.path.exists(rootfs + '/dev/pts'):
+            os.makedirs(rootfs + '/dev/pts')
+
+        # work around for LXC bug, rmmod module on the host system
+        shutil.copyfile(rootfs + '/bin/true', rootfs + '/bin/kmod')
 
     for host in conf['hosts']:
         print("[%s]" % host['name'])
@@ -98,7 +106,7 @@ def start():
             os.makedirs(lxc_dir)
             os.makedirs(aufs_rw_dir)
 
-        subprocess.call(['mount', '-t', 'aufs', '-o', 'br=%s:%s' % (aufs_rw_dir, '/var/lib/lxc/basesys'), 'none', lxc_dir ])
+        subprocess.call(['mount', '-t', 'aufs', '-o', 'br=%s:%s' % (aufs_rw_dir, '/var/lib/lxc/%s' % host['role']), 'none', lxc_dir ])
         #mount -t aufs -o br=/tmp/base_aufs/os-ci-test4:/var/lib/lxc/basesys none /var/lib/lxc/os-ci-test4
 
 
@@ -185,7 +193,6 @@ def start():
 
         a = augeas.Augeas(root="/var/lib/lxc/%s/rootfs" % host['name'])
         a.set("/files/etc/hostname/hostname", "%s" % host['name'])
-        a.set("/files/etc/default/puppet/START", "yes")
         a.save()
 
         setup_ssh_key(conf, host)

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -6,55 +6,71 @@ general:
     #ssh_key: /home/goneri/.ssh/id_rsa.pub
     ssh_key: /home/sbadia/.ssh/id_rsa_seb.pub
 edeploy:
-    #dir: /var/lib/debootstrap/install/RH6.5-H.1.0.0/openstack-full
-    #dir: /var/lib/debootstrap/install/U12-H.1.0.0/openstack-full
-    dir: /var/lib/debootstrap/install/D7-H.1.0.0/openstack-full
+    #dir: /var/lib/debootstrap/install/RH6.5-H.1.0.0
+    #dir: /var/lib/debootstrap/install/U12-H.1.0.0
+    dir: /var/lib/debootstrap/install/D7-H.1.0.0
 hosts:
   -
     address: 192.168.134.45
     name: os-ci-test1
+    role: openstack-full
   -
     address: 192.168.134.46
     name: os-ci-test2
+    role: openstack-full
   -
     address: 192.168.134.47
     name: os-ci-test3
+    role: openstack-full
   -
     address: 192.168.134.48
     name: os-ci-test4
+    role: puppet-master
   -
     address: 192.168.134.49
     name: os-ci-test5
+    role: openstack-full
   -
     address: 192.168.134.51
     name: os-ci-test7
+    role: openstack-full
   -
     address: 192.168.134.52
     name: os-ci-test8
+    role: openstack-full
   -
     address: 192.168.134.53
     name: os-ci-test9
+    role: openstack-full
   -
     address: 192.168.134.54
     name: os-ci-test10
+    role: openstack-full
   -
     address: 192.168.134.55
     name: os-ci-test11
+    role: openstack-full
   -
     address: 192.168.134.56
     name: os-ci-test12
+    role: openstack-full
   -
     address: 192.168.134.57
     name: os-ci-test13
+    role: openstack-full
   -
     address: 192.168.134.58
     name: os-ci-test14
+    role: openstack-full
   -
     address: 192.168.134.59
     name: os-ci-test15
+    role: openstack-full
   -
     address: 192.168.134.60
     name: os-ci-test16
+    role: openstack-full
   -
     address: 192.168.134.61
     name: os-ci-test17
+    role: openstack-full


### PR DESCRIPTION
Allow to use multiple eDeploy roles with edeploy-lxc.
