### PR TITLE
Add an explicit option to set cloudinit file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ has to deploy 6 differents virtual machines.
 1. He prepares a conf.yaml file with:
     - the domain
     - the name of a bridge interface
-    - a list of virtual machine (IP and name)
+    - a list of virtual machine (IP, name, role and cloudinit file)
 2. He calls `edeploy-lxc start` as root
 3. Start the puppet master, for example:
     ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@10.68.0.48 puppet master --debug --no-daemonize
@@ -53,6 +53,14 @@ For example `/etc/libvirt/qemu/networks/enovance0.xml`:
   </ip>
 </network>
 ```
+
+## Cloud-init
+
+Custom cloud-init files can also be used per virtual machines. The file path
+must be references in the conf.yaml with the key 'cloudinit'.
+
+They will be copied to /etc/cloud/cloud.cfg.d/ in order to be used as a flat
+file data-source.
 
 ### How to enable LXC
 

--- a/edeploy-lxc
+++ b/edeploy-lxc
@@ -197,12 +197,13 @@ def start():
 
         setup_ssh_key(conf, host)
 
-        if os.path.exists("%s.cloudinit" % host['role']):
-            print("    setting %s.cloudinit" % host['role'])
+        if 'cloudinit' in host:
+            cloudinit_name = os.path.basename(host['cloudinit']).replace('.cloudinit', '')
+            print("    setting cloudinit flat file datasource")
             open('/var/lib/lxc/%s/rootfs/etc/cloud/cloud.cfg.d/10_%s.cfg' % (
-                host['name'], host['role']
+                host['name'], cloudinit_name
             ), 'w').write(
-                open("%s.cloudinit" % host['role']).read()
+                open(host['cloudinit']).read()
             )
 
         print("    launching")


### PR DESCRIPTION
For each host, you can now use the 'cloudinit' key to explicitly specify
a cloudinit file.
